### PR TITLE
シミュレータの引数に試行回数を渡せるようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ $ python3 main.py
 10000 回試行
 
 ```sh
-$ for i in `seq 10000`; do  python3 main.py >> result.txt ; done;
+$ python3 main.py 10000 > result.txt
 ```
 
 集計

--- a/main.py
+++ b/main.py
@@ -61,7 +61,7 @@ def log_state(iter_num, players):
         logger.debug('%s, %s', iter_num, p)
 
 
-if __name__ == '__main__':
+def simulate():
 
     mashes = input.init_mashes()
     deck = input.init_deck(mashes)
@@ -78,9 +78,20 @@ if __name__ == '__main__':
         if is_dead(players):
             log_state(d, players)
             print("Dead " + str(d))
-            sys.exit()
+            return
         #log_state(d, players)
         digest(players)
 
     log_state(7, players)
     print("Survived")
+
+if __name__ == '__main__':
+    """
+    python3 main.py <count>
+    """
+    count = 1
+    if len(sys.argv) > 1:
+        count = int(sys.argv[1])
+
+    for i in range(0, count):
+        simulate()


### PR DESCRIPTION
```
$ for i in `seq 10000`; do  python3 main.py >> result.txt ; done;
```

うちの環境でこの子ちょっと時間かかり過ぎだったので、シミュレータ自体に試行回数を渡せるようにしました。
いちいちプロセスが立ち上がったり落ちたりしなくなった結果、爆速です。